### PR TITLE
Add two convenience methods to PluginMetadata

### DIFF
--- a/src/main/java/org/spongepowered/plugin/meta/PluginMetadata.java
+++ b/src/main/java/org/spongepowered/plugin/meta/PluginMetadata.java
@@ -208,7 +208,6 @@ public final class PluginMetadata implements Consumer<PluginMetadata> {
      * Adds the authors to the {@link List} of authors for this plugin.
      *
      * @param author The authors to add
-     * @return This object
      * @throws IllegalArgumentException If the author is empty or has any invalid authors
      */
     public void addAuthors(String... authors) {
@@ -332,7 +331,6 @@ public final class PluginMetadata implements Consumer<PluginMetadata> {
      * Adds the list of {@link PluginDependency}'s to this {@link PluginMetadata}.
      *
      * @param dependency The dependency to add
-     * @return This object
      * @throws IllegalArgumentException If the plugins are null or invalid
      */
     public void addDependencies(PluginDependency... dependencies) {

--- a/src/main/java/org/spongepowered/plugin/meta/PluginMetadata.java
+++ b/src/main/java/org/spongepowered/plugin/meta/PluginMetadata.java
@@ -203,6 +203,21 @@ public final class PluginMetadata implements Consumer<PluginMetadata> {
         checkArgument(!author.isEmpty(), "Author cannot be empty");
         this.authors.add(author);
     }
+    
+    /**
+     * Adds the authors to the {@link List} of authors for this plugin.
+     *
+     * @param author The authors to add
+     * @return This object
+     * @throws IllegalArgumentException If the author is empty or has any invalid authors
+     */
+    public void addAuthors(String... authors) {
+        checkNotNull(authors, "authors");
+        checkArgument(authors.length > 0, "Author list cannot be empty");
+        for(String author : authors) {
+        	addAuthor(author);
+        }
+    }
 
     /**
      * Removes an author from the {@link List} of authors for this plugin.
@@ -311,6 +326,20 @@ public final class PluginMetadata implements Consumer<PluginMetadata> {
         String id = dependency.getId();
         checkArgument(!this.dependencies.containsKey(id), "Duplicate dependency with plugin ID: %s", id);
         this.dependencies.put(id, dependency);
+    }
+    
+    /**
+     * Adds the list of {@link PluginDependency}'s to this {@link PluginMetadata}.
+     *
+     * @param dependency The dependency to add
+     * @return This object
+     * @throws IllegalArgumentException If the plugins are null or invalid
+     */
+    public void addDependencies(PluginDependency... dependencies) {
+    	checkNotNull(dependencies, "dependencies");
+    	for (PluginDependency dependency : dependencies) {
+    		addDependency(dependency);	
+    	}
     }
 
     /**


### PR DESCRIPTION
Adds methods for adding multiple authors or dependencies to PluginMetadata

Sorry I redid the PR because I screwed up the commits so many times.