### PR TITLE
Remove guava 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,6 @@ plugins {
 dependencies {
     api("org.checkerframework:checker-qual:3.4.1")
     api("com.google.code.gson:gson:2.8.0")
-    api("com.google.guava:guava:21.0")
 }
 
 allprojects {

--- a/mcmod-info/src/main/java/org/spongepowered/plugin/meta/McModInfo.java
+++ b/mcmod-info/src/main/java/org/spongepowered/plugin/meta/McModInfo.java
@@ -26,7 +26,6 @@ package org.spongepowered.plugin.meta;
 
 import static java.util.Arrays.asList;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonIOException;
@@ -50,7 +49,9 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Represents a serializer for {@link PluginMetadata} for the
@@ -265,7 +266,7 @@ public final class McModInfo {
     public static final class Builder {
 
         private final GsonBuilder gson = new GsonBuilder();
-        private final ImmutableMap.Builder<String, Class<?>> extensions = ImmutableMap.builder();
+        private final Map<String, Class<?>> extensions = new HashMap<>();
 
         private Builder() {
         }
@@ -319,7 +320,7 @@ public final class McModInfo {
          * @return The built serializer
          */
         public McModInfo build() {
-            return new McModInfo(new ModMetadataCollectionAdapter(new ModMetadataAdapter(this.gson.create(), this.extensions.build())));
+            return new McModInfo(new ModMetadataCollectionAdapter(new ModMetadataAdapter(this.gson.create(), this.extensions)));
         }
 
     }

--- a/mcmod-info/src/main/java/org/spongepowered/plugin/meta/PluginDependency.java
+++ b/mcmod-info/src/main/java/org/spongepowered/plugin/meta/PluginDependency.java
@@ -24,13 +24,10 @@
  */
 package org.spongepowered.plugin.meta;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.base.Strings.emptyToNull;
-
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
 import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.Objects;
+import java.util.StringJoiner;
 
 /**
  * Represents a dependency on another plugin.
@@ -79,10 +76,12 @@ public final class PluginDependency {
      * @see #getVersion() Version range syntax
      */
     public PluginDependency(LoadOrder loadOrder, String id, @Nullable String version, boolean optional) {
-        this.loadOrder = checkNotNull(loadOrder, "loadOrder");
-        this.id = checkNotNull(id, "id");
-        checkArgument(!id.isEmpty(), "id cannot be empty");
-        this.version = emptyToNull(version);
+        this.loadOrder = Objects.requireNonNull(loadOrder, "loadOrder");
+        this.id = Objects.requireNonNull(id, "id");
+        if (id.isEmpty()) {
+            throw new IllegalArgumentException("id cannot be empty");
+        }
+        this.version = version != null && !version.isEmpty() ? version : null;
         this.optional = optional;
     }
 
@@ -182,23 +181,22 @@ public final class PluginDependency {
         PluginDependency that = (PluginDependency) o;
         return this.loadOrder == that.loadOrder
                 && this.id.equals(that.id)
-                && Objects.equal(this.version, that.version)
+                && Objects.equals(this.version, that.version)
                 && this.optional == that.optional;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(this.loadOrder, this.id, this.version, this.optional);
+        return Objects.hash(this.loadOrder, this.id, this.version, this.optional);
     }
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this)
-                .omitNullValues()
-                .addValue(this.loadOrder)
-                .add("id", this.id)
-                .add("version", this.version)
-                .add("optional", this.optional)
+        return new StringJoiner(", ", PluginDependency.class.getSimpleName() + "[", "]")
+                .add(this.loadOrder.toString())
+                .add("id=" + this.id)
+                .add("version=" + Objects.toString(this.version))
+                .add("optional=" + this.optional)
                 .toString();
     }
 

--- a/mcmod-info/src/main/java/org/spongepowered/plugin/meta/gson/ModMetadataAdapter.java
+++ b/mcmod-info/src/main/java/org/spongepowered/plugin/meta/gson/ModMetadataAdapter.java
@@ -24,7 +24,6 @@
  */
 package org.spongepowered.plugin.meta.gson;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
 import com.google.gson.JsonParseException;
 import com.google.gson.TypeAdapter;
@@ -35,6 +34,7 @@ import org.spongepowered.plugin.meta.PluginDependency;
 import org.spongepowered.plugin.meta.PluginMetadata;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -42,14 +42,14 @@ import java.util.Set;
 
 public final class ModMetadataAdapter extends TypeAdapter<PluginMetadata> {
 
-    public static final ModMetadataAdapter DEFAULT = new ModMetadataAdapter(new Gson(), ImmutableMap.of());
+    public static final ModMetadataAdapter DEFAULT = new ModMetadataAdapter(new Gson(), Collections.emptyMap());
 
     private static final char VERSION_SEPARATOR = '@';
 
     private final Gson gson;
-    private final ImmutableMap<String, Class<?>> extensions;
+    private final Map<String, Class<?>> extensions;
 
-    public ModMetadataAdapter(Gson gson, ImmutableMap<String, Class<?>> extensions) {
+    public ModMetadataAdapter(Gson gson, Map<String, Class<?>> extensions) {
         this.gson = gson;
         this.extensions = extensions;
     }
@@ -58,8 +58,8 @@ public final class ModMetadataAdapter extends TypeAdapter<PluginMetadata> {
         return this.gson;
     }
 
-    public ImmutableMap<String, Class<?>> getExtensions() {
-        return this.extensions;
+    public Map<String, Class<?>> getExtensions() {
+        return Collections.unmodifiableMap(this.extensions);
     }
 
     public Class<?> getExtension(String key) {

--- a/mcmod-info/src/main/java/org/spongepowered/plugin/meta/gson/ModMetadataCollectionAdapter.java
+++ b/mcmod-info/src/main/java/org/spongepowered/plugin/meta/gson/ModMetadataCollectionAdapter.java
@@ -24,13 +24,14 @@
  */
 package org.spongepowered.plugin.meta.gson;
 
-import com.google.common.collect.ImmutableList;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import org.spongepowered.plugin.meta.PluginMetadata;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public final class ModMetadataCollectionAdapter extends TypeAdapter<List<PluginMetadata>> {
@@ -46,12 +47,12 @@ public final class ModMetadataCollectionAdapter extends TypeAdapter<List<PluginM
     @Override
     public List<PluginMetadata> read(JsonReader in) throws IOException {
         in.beginArray();
-        ImmutableList.Builder<PluginMetadata> result = ImmutableList.builder();
+        final List<PluginMetadata> list = new ArrayList<>();
         while (in.hasNext()) {
-            result.add(this.metadataAdapter.read(in));
+            list.add(this.metadataAdapter.read(in));
         }
         in.endArray();
-        return result.build();
+        return Collections.unmodifiableList(list);
     }
 
     @Override

--- a/mcmod-info/src/main/java/org/spongepowered/plugin/meta/version/DefaultArtifactVersion.java
+++ b/mcmod-info/src/main/java/org/spongepowered/plugin/meta/version/DefaultArtifactVersion.java
@@ -24,11 +24,11 @@
  */
 package org.spongepowered.plugin.meta.version;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.framework.qual.DefaultQualifier;
+
+import java.util.Objects;
 
 @DefaultQualifier(NonNull.class)
 public final class DefaultArtifactVersion implements ArtifactVersion {
@@ -36,7 +36,7 @@ public final class DefaultArtifactVersion implements ArtifactVersion {
     private final ComparableVersion version;
 
     public DefaultArtifactVersion(String version) {
-        checkNotNull(version, "version");
+        Objects.requireNonNull(version, "version");
         this.version = new ComparableVersion(version);
     }
 

--- a/mcmod-info/src/test/java/org/spongepowered/plugin/meta/PluginMetadataTest.java
+++ b/mcmod-info/src/test/java/org/spongepowered/plugin/meta/PluginMetadataTest.java
@@ -24,8 +24,9 @@
  */
 package org.spongepowered.plugin.meta;
 
-import com.google.common.base.Strings;
 import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -48,8 +49,8 @@ class PluginMetadataTest {
         assertFalse(ID_PATTERN.matcher("aB").matches());
 
         // up to 64 characters
-        assertTrue(ID_PATTERN.matcher(Strings.repeat("a", 64)).matches());
+        assertTrue(ID_PATTERN.matcher(String.join("", Collections.nCopies(64, "a"))).matches());
         // but no longer
-        assertFalse(ID_PATTERN.matcher(Strings.repeat("a", 65)).matches());
+        assertFalse(ID_PATTERN.matcher(String.join("", Collections.nCopies(65, "a"))).matches());
     }
 }

--- a/src/main/java/org/spongepowered/plugin/metadata/PluginContributor.java
+++ b/src/main/java/org/spongepowered/plugin/metadata/PluginContributor.java
@@ -24,12 +24,11 @@
  */
 package org.spongepowered.plugin.metadata;
 
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Preconditions;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.Objects;
 import java.util.Optional;
+import java.util.StringJoiner;
 
 /**
  * Specification for an entity considered to be a "contributor" to a plugin.
@@ -80,9 +79,9 @@ public final class PluginContributor {
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this)
-            .add("name", this.name)
-            .add("description", this.description)
+        return new StringJoiner(", ", PluginContributor.class.getSimpleName() + "[", "]")
+            .add("name=" + this.name)
+            .add("description=" + this.description)
             .toString();
     }
 
@@ -91,7 +90,7 @@ public final class PluginContributor {
         String name, description;
 
         public Builder setName(final String name) {
-            this.name = Preconditions.checkNotNull(name);
+            this.name = Objects.requireNonNull(name);
             return this;
         }
 
@@ -101,7 +100,7 @@ public final class PluginContributor {
         }
 
         public PluginContributor build() {
-            Preconditions.checkNotNull(this.name);
+            Objects.requireNonNull(this.name);
 
             return new PluginContributor(this);
         }

--- a/src/main/java/org/spongepowered/plugin/metadata/PluginDependency.java
+++ b/src/main/java/org/spongepowered/plugin/metadata/PluginDependency.java
@@ -24,10 +24,8 @@
  */
 package org.spongepowered.plugin.metadata;
 
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Preconditions;
-
 import java.util.Objects;
+import java.util.StringJoiner;
 
 /**
  * Specification for an entity considered to be a "dependency" for a plugin.
@@ -95,11 +93,11 @@ public final class PluginDependency {
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this)
-                .add("id", this.id)
-                .add("version", this.version)
-                .add("loadOrder", this.loadOrder)
-                .add("optional", this.optional)
+        return new StringJoiner(", ", PluginDependency.class.getSimpleName() + "[", "]")
+                .add("id=" + this.id)
+                .add("version=" + this.version)
+                .add("loadOrder=" + this.loadOrder)
+                .add("optional=" + this.optional)
                 .toString();
     }
 
@@ -124,12 +122,12 @@ public final class PluginDependency {
         boolean optional = false;
 
         public Builder setId(final String id) {
-            this.id = Preconditions.checkNotNull(id);
+            this.id = Objects.requireNonNull(id);
             return this;
         }
 
         public Builder setVersion(final String version) {
-            this.version = Preconditions.checkNotNull(version);
+            this.version = Objects.requireNonNull(version);
             return this;
         }
 
@@ -144,8 +142,8 @@ public final class PluginDependency {
         }
 
         public PluginDependency build() {
-            Preconditions.checkNotNull(this.id);
-            Preconditions.checkNotNull(this.version);
+            Objects.requireNonNull(this.id);
+            Objects.requireNonNull(this.version);
 
             return new PluginDependency(this);
         }

--- a/src/main/java/org/spongepowered/plugin/metadata/PluginLinks.java
+++ b/src/main/java/org/spongepowered/plugin/metadata/PluginLinks.java
@@ -24,11 +24,11 @@
  */
 package org.spongepowered.plugin.metadata;
 
-import com.google.common.base.MoreObjects;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.net.URL;
 import java.util.Optional;
+import java.util.StringJoiner;
 
 /**
  * Specification for an entity representing the links to "web resources" of a plugin.
@@ -70,10 +70,10 @@ public final class PluginLinks {
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this)
-            .add("homepage", this.homepage)
-            .add("source", this.source)
-            .add("issues", this.issues)
+        return new StringJoiner(", ", PluginLinks.class.getSimpleName() + "[", "]")
+            .add("homepage=" + this.homepage)
+            .add("source=" + this.source)
+            .add("issues=" + this.issues)
             .toString();
     }
 

--- a/src/main/java/org/spongepowered/plugin/metadata/PluginMetadata.java
+++ b/src/main/java/org/spongepowered/plugin/metadata/PluginMetadata.java
@@ -24,8 +24,6 @@
  */
 package org.spongepowered.plugin.metadata;
 
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Preconditions;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.ArrayList;
@@ -33,7 +31,9 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.StringJoiner;
 
 /**
  * The specification of a typical plugin's metadata as defined by this library
@@ -50,7 +50,7 @@ public final class PluginMetadata {
     private final Map<String, Object> extraMetadata;
 
     private PluginMetadata(final Builder builder) {
-        Preconditions.checkNotNull(builder);
+        Objects.requireNonNull(builder);
 
         this.id = builder.id;
         this.name = builder.name;
@@ -105,16 +105,16 @@ public final class PluginMetadata {
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this)
-            .add("id", this.id)
-            .add("name", this.name)
-            .add("version", this.version)
-            .add("mainClass", this.mainClass)
-            .add("description", this.description)
-            .add("links", this.links)
-            .add("contributors", this.contributors)
-            .add("dependencies", this.dependencies)
-            .add("extraMetadata", this.extraMetadata)
+        return new StringJoiner(", ", PluginMetadata.class.getSimpleName() + "[", "]")
+            .add("id=" + this.id)
+            .add("name=" + this.name)
+            .add("version=" + this.version)
+            .add("mainClass=" + this.mainClass)
+            .add("description=" + this.description)
+            .add("links=" + this.links)
+            .add("contributors=" + this.contributors)
+            .add("dependencies=" + this.dependencies)
+            .add("extraMetadata=" + this.extraMetadata)
             .toString();
     }
 
@@ -127,7 +127,7 @@ public final class PluginMetadata {
         Map<String, Object> extraMetadata = new HashMap<>();
 
         public Builder setId(final String id) {
-            this.id = Preconditions.checkNotNull(id);
+            this.id = Objects.requireNonNull(id);
             return this;
         }
 
@@ -137,12 +137,12 @@ public final class PluginMetadata {
         }
 
         public Builder setVersion(final String version) {
-            this.version = Preconditions.checkNotNull(version);
+            this.version = Objects.requireNonNull(version);
             return this;
         }
 
         public Builder setMainClass(final String mainClass) {
-            this.mainClass = Preconditions.checkNotNull(mainClass);
+            this.mainClass = Objects.requireNonNull(mainClass);
             return this;
         }
 
@@ -152,48 +152,48 @@ public final class PluginMetadata {
         }
 
         public Builder setLinks(final PluginLinks links) {
-            this.links = Preconditions.checkNotNull(links);
+            this.links = Objects.requireNonNull(links);
             return this;
         }
 
         public Builder setContributors(final List<PluginContributor> contributors) {
-            this.contributors = Preconditions.checkNotNull(contributors);
+            this.contributors = Objects.requireNonNull(contributors);
             return this;
         }
 
         public Builder contributor(final PluginContributor developer) {
-            this.contributors.add(Preconditions.checkNotNull(developer));
+            this.contributors.add(Objects.requireNonNull(developer));
             return this;
         }
 
         public Builder setDependencies(final List<PluginDependency> dependencies) {
-            this.dependencies = Preconditions.checkNotNull(dependencies);
+            this.dependencies = Objects.requireNonNull(dependencies);
             return this;
         }
 
         public Builder dependency(final PluginDependency dependency) {
-            Preconditions.checkNotNull(dependency);
+            Objects.requireNonNull(dependency);
             this.dependencies.add(dependency);
             return this;
         }
 
         public Builder setExtraMetadata(final Map<String, Object> extraMetadata) {
-            this.extraMetadata = Preconditions.checkNotNull(extraMetadata);
+            this.extraMetadata = Objects.requireNonNull(extraMetadata);
             return this;
         }
 
         public Builder extraMetadata(final String key, final Object value) {
-            Preconditions.checkNotNull(key);
-            Preconditions.checkNotNull(value);
+            Objects.requireNonNull(key);
+            Objects.requireNonNull(value);
 
             this.extraMetadata.put(key, value);
             return this;
         }
 
         public PluginMetadata build() {
-            Preconditions.checkNotNull(this.id);
-            Preconditions.checkNotNull(this.version);
-            Preconditions.checkNotNull(this.mainClass);
+            Objects.requireNonNull(this.id);
+            Objects.requireNonNull(this.version);
+            Objects.requireNonNull(this.mainClass);
 
             return new PluginMetadata(this);
         }

--- a/src/main/java/org/spongepowered/plugin/metadata/PluginMetadataContainer.java
+++ b/src/main/java/org/spongepowered/plugin/metadata/PluginMetadataContainer.java
@@ -24,11 +24,10 @@
  */
 package org.spongepowered.plugin.metadata;
 
-import com.google.common.base.Preconditions;
-
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -39,7 +38,7 @@ public final class PluginMetadataContainer {
     private final Map<String, PluginMetadata> pluginMetadata;
 
     public PluginMetadataContainer(final Iterable<PluginMetadata> pluginMetadata) {
-        Preconditions.checkNotNull(pluginMetadata);
+        Objects.requireNonNull(pluginMetadata);
 
         this.pluginMetadata = new HashMap<>();
 
@@ -54,7 +53,7 @@ public final class PluginMetadataContainer {
      * @return The metadata or {@link Optional#empty()} if not present
      */
     public Optional<PluginMetadata> getMetadata(final String pluginId) {
-        Preconditions.checkNotNull(pluginId);
+        Objects.requireNonNull(pluginId);
 
         return Optional.ofNullable(this.pluginMetadata.get(pluginId));
     }

--- a/src/main/java/org/spongepowered/plugin/metadata/parser/PluginMetadataAdapter.java
+++ b/src/main/java/org/spongepowered/plugin/metadata/parser/PluginMetadataAdapter.java
@@ -24,7 +24,6 @@
  */
 package org.spongepowered.plugin.metadata.parser;
 
-import com.google.common.base.Preconditions;
 import com.google.gson.Gson;
 import com.google.gson.JsonParseException;
 import com.google.gson.TypeAdapter;
@@ -41,6 +40,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -49,7 +49,7 @@ public final class PluginMetadataAdapter extends TypeAdapter<PluginMetadata> {
     private final Gson gson;
 
     public PluginMetadataAdapter(final Gson gson) {
-        this.gson = Preconditions.checkNotNull(gson);
+        this.gson = Objects.requireNonNull(gson);
     }
 
     @Override

--- a/src/main/java/org/spongepowered/plugin/metadata/parser/PluginMetadataCollectionAdapter.java
+++ b/src/main/java/org/spongepowered/plugin/metadata/parser/PluginMetadataCollectionAdapter.java
@@ -24,14 +24,15 @@
  */
 package org.spongepowered.plugin.metadata.parser;
 
-import com.google.common.collect.ImmutableList;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import org.spongepowered.plugin.metadata.PluginMetadata;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 public final class PluginMetadataCollectionAdapter extends TypeAdapter<Collection<PluginMetadata>> {
@@ -58,11 +59,11 @@ public final class PluginMetadataCollectionAdapter extends TypeAdapter<Collectio
     @Override
     public List<PluginMetadata> read(final JsonReader in) throws IOException {
         in.beginArray();
-        final ImmutableList.Builder<PluginMetadata> builder = ImmutableList.builder();
+        final List<PluginMetadata> list = new ArrayList<>();
         while (in.hasNext()) {
-            builder.add(this.adapter.read(in));
+            list.add(this.adapter.read(in));
         }
         in.endArray();
-        return builder.build();
+        return Collections.unmodifiableList(list);
     }
 }


### PR DESCRIPTION
Same as the plugin-spi PR.

Replacing `checkNotNull` with `requireNonNull` and `MoreObjects` with `StringTokenizer`.

The immutable collections are either:

- local variables created and then return (in this case, a Collections#unmodifiable.. is equivalent).
- field used by the builder pattern and passed to the private ctor of the object (basically moving the collection internally).

The only notable change is `ModMetadataAdapter#getExtension` changing its return type (`ImmutableMap`  -> `Map`)